### PR TITLE
Let each individual interpreter configure completionKey

### DIFF
--- a/docs/development/writing_zeppelin_interpreter.md
+++ b/docs/development/writing_zeppelin_interpreter.md
@@ -74,7 +74,8 @@ Here is an example of `interpreter-setting.json` on your own interpreter.
     },
     "editor": {
       "language": "your-syntax-highlight-language",
-      "editOnDblClick": false
+      "editOnDblClick": false,
+      "completionKey": "TAB"
     }
   },
   {
@@ -128,6 +129,19 @@ If your interpreter uses mark-up language such as markdown or HTML, set `editOnD
   "editOnDblClick": false
 }
 ```
+
+### Completion key (Optional)
+By default, `Ctrl+dot(.)` brings autocompletion list in the editor.
+Through `completionKey`, each interpreter can configure autocompletion key.
+Currently `TAB` is only available option.
+
+```
+"editor": {
+  "completionKey": "TAB"
+}
+```
+
+
 ## Install your interpreter binary
 
 Once you have built your interpreter, you can place it under the interpreter directory with all its dependencies.

--- a/python/src/main/resources/interpreter-setting.json
+++ b/python/src/main/resources/interpreter-setting.json
@@ -21,7 +21,8 @@
     },
     "editor": {
       "language": "python",
-      "editOnDblClick": false
+      "editOnDblClick": false,
+      "completionKey": "TAB"
     }
   },
   {

--- a/spark/src/main/resources/interpreter-setting.json
+++ b/spark/src/main/resources/interpreter-setting.json
@@ -71,7 +71,8 @@
     },
     "editor": {
       "language": "scala",
-      "editOnDblClick": false
+      "editOnDblClick": false,
+      "completionKey": "TAB"
     }
   },
   {
@@ -110,7 +111,8 @@
     },
     "editor": {
       "language": "sql",
-      "editOnDblClick": false
+      "editOnDblClick": false,
+      "completionKey": "TAB"
     }
   },
   {
@@ -135,7 +137,8 @@
     },
     "editor": {
       "language": "scala",
-      "editOnDblClick": false
+      "editOnDblClick": false,
+      "completionKey": "TAB"
     }
   },
   {
@@ -153,7 +156,8 @@
     },
     "editor": {
       "language": "python",
-      "editOnDblClick": false
+      "editOnDblClick": false,
+      "completionKey": "TAB"
     }
   }
 ]

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -187,7 +187,7 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
 
   const isTabCompletion = function() {
     const completionKey = $scope.paragraph.config.editorSetting.completionKey
-    return completionKey == 'TAB'
+    return completionKey === 'TAB'
   }
 
   $scope.$on('updateParagraphOutput', function (event, data) {

--- a/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
+++ b/zeppelin-web/src/app/notebook/paragraph/paragraph.controller.js
@@ -185,6 +185,11 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
     }
   }
 
+  const isTabCompletion = function() {
+    const completionKey = $scope.paragraph.config.editorSetting.completionKey
+    return completionKey == 'TAB'
+  }
+
   $scope.$on('updateParagraphOutput', function (event, data) {
     if ($scope.paragraph.id === data.paragraphId) {
       if (!$scope.paragraph.results) {
@@ -843,9 +848,9 @@ function ParagraphCtrl ($scope, $rootScope, $route, $window, $routeParams, $loca
           let currentLine = $scope.editor.session.getLine(iCursor.row)
           let isAllTabs = currentLine.split('').every(function(char) { return (char === '\t' || char === ' ') })
 
-          // If user has pressed tab on first line char or if editor mode is %md, keep existing behavior
+          // If user has pressed tab on first line char or if isTabCompletion() is false, keep existing behavior
           // If user has pressed tab anywhere in between and editor mode is not %md, show autocomplete
-          if (!isAllTabs && iCursor.column && $scope.paragraph.config.editorMode !== 'ace/mode/markdown') {
+          if (!isAllTabs && iCursor.column && isTabCompletion()) {
             $scope.editor.execCommand('startAutocomplete')
           } else {
             ace.config.loadModule('ace/ext/language_tools', function () {


### PR DESCRIPTION
This patch makes each interpreter choose completion key.
Tab completion key is applied to %python, %spark, %spark.sql, %spark.pyspark, %spark.dep interpreters.

One limitation is, interpreter setting pre-exists this patch does not apply tab completion.
New interpreter setting after this patch will work with tab completion.
Reason is, Zeppelin write editor configuration under conf/interpreter.json on interpreterSetting creation and read it. So even if an interpreter is upgraded and includes new editor configuration, zeppelin still reads old information from conf/interpreter.json unless user recreates it. 

This is I think wrong behavior need to be addressed in a separate issue.

Please @malayhm take a look this patch and merge if you're okay.